### PR TITLE
Host on heroku

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "teabot_stats"]
+	path = teabot_stats
+	url = https://github.com/alsuren/teabot_stats.git

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: gunicorn --log-level debug --workers 4 teabot_endpoints.endpoints:app
+#web: ./run
+web: python teabot_endpoints/endpoints.py

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --log-level debug --workers 4 teabot_endpoints.endpoints:app

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-#web: ./run
-web: python teabot_endpoints/endpoints.py
+web: ./run
+#web: python teabot_endpoints/endpoints.py

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: ./run
+web: gunicorn --log-level debug -w 4 -b 0.0.0.0:${PORT:-8000} teabot_endpoints.endpoints:app
 #web: python teabot_endpoints/endpoints.py

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "//": "This config just proxies onto teabot_stats/package.json.",
+  "name": "teabot_stats",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "dependencies": {
+  },
+  "devDependencies": {
+  },
+  "scripts": {
+    "postinstall": "cd teabot_stats && npm install",
+    "test": "cd teabot_stats && npm run test",
+    "lint": "cd teabot_stats && npm run lint",
+    "build": "cd teabot_stats && npm run build",
+    "watch": "cd teabot_stats && npm run watch",
+    "heroku-postbuild": "cd teabot_stats && npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AaronKalair/teabot_stats.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/AaronKalair/teabot_stats/issues"
+  },
+  "homepage": "https://github.com/AaronKalair/teabot_stats#readme"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ slacker==0.9.10
 rollbar==0.13.2
 blinker==1.4
 psycopg2==2.7.1
+pusher==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ peewee==2.8.0
 slacker==0.9.10
 rollbar==0.13.2
 blinker==1.4
+psycopg2==2.7.1

--- a/run
+++ b/run
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec gunicorn --log-level debug -w 4 -b 0.0.0.0:${PORT:-8000} teabot_endpoints.endpoints:app
+exec gunicorn --log-level debug -w 4 -b 127.0.0.1:8000 teabot_endpoints.endpoints:app

--- a/run
+++ b/run
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec gunicorn --log-level debug -w 4 -b 127.0.0.1:8000 teabot_endpoints.endpoints:app
+exec gunicorn --log-level debug -w 4 -b 127.0.0.1:${PORT:-8000} teabot_endpoints.endpoints:app

--- a/run
+++ b/run
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec gunicorn --log-level debug -w 4 -b 127.0.0.1:${PORT:-8000} teabot_endpoints.endpoints:app
+exec gunicorn --log-level debug -w 4 -b 0.0.0.0:${PORT:-8000} teabot_endpoints.endpoints:app

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -8,7 +8,7 @@ import json
 from datetime import datetime
 
 
-app = Flask(__name__, static_url_path='', static_folder='teabot_stats')
+app = Flask(__name__)
 slack_communicator_wrapper = SlackCommunicator()
 
 

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -266,4 +266,4 @@ print "imported"
 if __name__ == "__main__":
     print "grumble grumble"
     port = int(os.environ.get("PORT", "8000"))
-    app.run(host="0.0.0.0", port=port)
+    app.run(host="0.0.0.0", debug=True, port=port)

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -264,4 +264,5 @@ def getNumberOfTeapotRequests():
 
 
 if __name__ == "__main__":
+    print "grumble grumble"
     app.run(host="127.0.0.1", debug=True, port=8000)

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -154,7 +154,7 @@ def numberOfNewTeapots():
 
 
 def _get_current_time():
-    return datetime.now()
+    return datetime.utcnow()
 
 
 @app.route("/teapotAge")

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -8,7 +8,7 @@ import json
 from datetime import datetime
 
 
-app = Flask(__name__)
+app = Flask(__name__, static_url_path='', static_folder='teabot_stats')
 slack_communicator_wrapper = SlackCommunicator()
 
 

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -265,4 +265,5 @@ def getNumberOfTeapotRequests():
 print "imported"
 if __name__ == "__main__":
     print "grumble grumble"
-    app.run(host="127.0.0.1", debug=True)
+    port = int(os.environ.get("PORT", "8000"))
+    app.run(host="127.0.0.1", debug=True, port=port)

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -256,6 +256,7 @@ def getNumberOfTeapotRequests():
         {'teaRequests': number of tea requests}
 
     """
+    print "mumble mumble"
     tea_requests = PotMaker.get_number_of_teapot_requests() + \
         slack_communicator_wrapper.get_message_reaction_count()
 

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -266,4 +266,4 @@ print "imported"
 if __name__ == "__main__":
     print "grumble grumble"
     port = int(os.environ.get("PORT", "8000"))
-    app.run(host="127.0.0.1", debug=True, port=port)
+    app.run(host="0.0.0.0", port=port)

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -262,7 +262,7 @@ def getNumberOfTeapotRequests():
 
     return jsonify({'teaRequests': tea_requests})
 
-
+print "imported"
 if __name__ == "__main__":
     print "grumble grumble"
-    app.run(host="127.0.0.1", debug=True, port=8000)
+    app.run(host="127.0.0.1", debug=True)

--- a/teabot_endpoints/endpoints.py
+++ b/teabot_endpoints/endpoints.py
@@ -256,14 +256,12 @@ def getNumberOfTeapotRequests():
         {'teaRequests': number of tea requests}
 
     """
-    print "mumble mumble"
     tea_requests = PotMaker.get_number_of_teapot_requests() + \
         slack_communicator_wrapper.get_message_reaction_count()
 
     return jsonify({'teaRequests': tea_requests})
 
-print "imported"
+
 if __name__ == "__main__":
-    print "grumble grumble"
     port = int(os.environ.get("PORT", "8000"))
-    app.run(host="0.0.0.0", debug=True, port=port)
+    app.run(host="0.0.0.0", port=port, debug=True)

--- a/teabot_endpoints/models.py
+++ b/teabot_endpoints/models.py
@@ -12,7 +12,7 @@ if DATABASE_URL.startswith("postgres"):
     url = urlparse.urlparse(os.environ["DATABASE_URL"])
     db = PostgresqlDatabase(
         database=url.path[1:], user=url.username, password=url.password,
-        host=url.hostname, port=url.port)
+        host=url.hostname, port=url.port, autorollback=True)
 else:
     db = SqliteExtDatabase('teapot.db')
 

--- a/teabot_endpoints/models.py
+++ b/teabot_endpoints/models.py
@@ -1,9 +1,15 @@
+import os
+
 from peewee import Model, DateTimeField, OperationalError, CharField, \
-    IntegerField, ForeignKeyField, BooleanField
+    IntegerField, ForeignKeyField, BooleanField, PostgresqlDatabase
 from playhouse.sqlite_ext import SqliteExtDatabase
 from datetime import datetime
 
-db = SqliteExtDatabase('teapot.db')
+DATABASE_URL = os.environ.get("DATABASE_URL", "")
+if DATABASE_URL.startswith("postgres"):
+    db = PostgresqlDatabase(DATABASE_URL)
+else:
+    db = SqliteExtDatabase('teapot.db')
 
 
 class BaseModel(Model):

--- a/teabot_endpoints/models.py
+++ b/teabot_endpoints/models.py
@@ -184,11 +184,11 @@ class SlackMessages(BaseModel):
 
 if __name__ == "__main__":
     try:
-        State.create_table()
+        PotMaker.create_table()
     except OperationalError:
         print "The table already exists"
     try:
-        PotMaker.create_table()
+        State.create_table()
     except OperationalError:
         print "The table already exists"
     try:

--- a/teabot_endpoints/models.py
+++ b/teabot_endpoints/models.py
@@ -7,7 +7,12 @@ from datetime import datetime
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
 if DATABASE_URL.startswith("postgres"):
-    db = PostgresqlDatabase(DATABASE_URL)
+    import urlparse
+    urlparse.uses_netloc.append('postgres')
+    url = urlparse.urlparse(os.environ["DATABASE_URL"])
+    db = PostgresqlDatabase(
+        database=url.path[1:], user=url.username, password=url.password,
+        host=url.hostname, port=url.port)
 else:
     db = SqliteExtDatabase('teapot.db')
 

--- a/teabot_endpoints/models.py
+++ b/teabot_endpoints/models.py
@@ -116,7 +116,7 @@ class State(BaseModel):
     for the latest entry to tell people about the state of the teapot
     """
     state = CharField()
-    timestamp = DateTimeField(default=datetime.now, index=True)
+    timestamp = DateTimeField(default=datetime.utcnow, index=True)
     num_of_cups = IntegerField()
     weight = IntegerField(null=True)
     temperature = IntegerField(null=True)

--- a/teabot_endpoints/settings.py
+++ b/teabot_endpoints/settings.py
@@ -1,2 +1,4 @@
-API_TOKEN = ''
+import os
+
+API_TOKEN = os.environ.get('SLACK_API_TOKEN', '')
 TEABOT_ROOM = '#teapot'

--- a/teabot_endpoints/static
+++ b/teabot_endpoints/static
@@ -1,0 +1,1 @@
+../teabot_stats/

--- a/teabot_endpoints/tests/test_endpoints.py
+++ b/teabot_endpoints/tests/test_endpoints.py
@@ -32,7 +32,7 @@ class TestEndpoints(TestCase):
     def test_tea_ready_no_claim(self, mock_slack):
         State.create(
             state="FULL_TEAPOT",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=3
         )
         result = self.app.post("/teaReady")
@@ -61,7 +61,7 @@ class TestEndpoints(TestCase):
         )
         State.create(
             state="FULL_TEAPOT",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=3,
             claimed_by=maker
         )
@@ -87,12 +87,12 @@ class TestEndpoints(TestCase):
     def test_tea_webhook_data(self):
         State.create(
             state="TEAPOT FULL",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=3
         )
         State.create(
             state="TEAPOT EMPTY",
-            timestamp=datetime.now() - timedelta(weeks=1),
+            timestamp=datetime.utcnow() - timedelta(weeks=1),
             num_of_cups=2
         )
         result = self.app.post("/teabotWebhook")
@@ -103,12 +103,12 @@ class TestEndpoints(TestCase):
     def test_tea_webhook_data_cold_tea(self):
         State.create(
             state="COLD_TEAPOT",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=3
         )
         State.create(
             state="TEAPOT EMPTY",
-            timestamp=datetime.now() - timedelta(weeks=1),
+            timestamp=datetime.utcnow() - timedelta(weeks=1),
             num_of_cups=2
         )
         result = self.app.post("/teabotWebhook")
@@ -120,7 +120,7 @@ class TestEndpoints(TestCase):
     def test_store_state(self):
         database_entries = [d for d in State.select()]
         self.assertEqual(len(database_entries), 0)
-        now = datetime.now()
+        now = datetime.utcnow()
         result = self.app.post(
             "/storeState",
             data=json.dumps({
@@ -149,7 +149,7 @@ class TestEndpoints(TestCase):
     def test_human_teapot_state_cold_tea(self):
         state = State.create(
             state="COLD_TEAPOT",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=3
         )
         result = _human_teapot_state(state)
@@ -158,7 +158,7 @@ class TestEndpoints(TestCase):
     def test_human_teapot_state_cold_tea_one_cup(self):
         state = State.create(
             state="COLD_TEAPOT",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=1
         )
         result = _human_teapot_state(state)
@@ -167,7 +167,7 @@ class TestEndpoints(TestCase):
     def test_human_teapot_state_good_tea_1_cup(self):
         state = State.create(
             state="TEAPOT_FULL",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=1
         )
         result = _human_teapot_state(state)
@@ -176,7 +176,7 @@ class TestEndpoints(TestCase):
     def test_human_teapot_state_good_tea_many_cups(self):
         state = State.create(
             state="TEAPOT_FULL",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=2
         )
         result = _human_teapot_state(state)

--- a/teabot_endpoints/tests/test_models.py
+++ b/teabot_endpoints/tests/test_models.py
@@ -20,12 +20,12 @@ class TestModels(TestCase):
     def test_get_latest_state(self):
         State.create(
             state="TEAPOT_FULL",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=3
         )
         State.create(
             state="TEAPOT_EMPTY",
-            timestamp=datetime.now() - timedelta(weeks=1),
+            timestamp=datetime.utcnow() - timedelta(weeks=1),
             num_of_cups=0
         )
         result = State.get_newest_state()
@@ -35,17 +35,17 @@ class TestModels(TestCase):
     def test_get_number_of_new_teapots(self):
         State.create(
             state="FULL_TEAPOT",
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.utcnow().isoformat(),
             num_of_cups=3
         )
         State.create(
             state="FULL_TEAPOT",
-            timestamp=datetime.now() - timedelta(weeks=1),
+            timestamp=datetime.utcnow() - timedelta(weeks=1),
             num_of_cups=0
         )
         State.create(
             state="EMPTY_TEAPOT",
-            timestamp=datetime.now() - timedelta(weeks=1),
+            timestamp=datetime.utcnow() - timedelta(weeks=1),
             num_of_cups=0
         )
         result = State.get_number_of_new_teapots()


### PR DESCRIPTION
I realised that teabot is so low-traffic that it should be possible to host it on a heroku free-tier server.

WIP lives on: https://teabot-alsuren.herokuapp.com/numberOfNewTeapots and https://teabot-alsuren.herokuapp.com/static/index.html

TODO:
- [x] Add https://github.com/AaronKalair/teabot_stats as a submodule, and work out to get heroku to build it for you.
- [x] Pull the slack secrets out of environment variables, so it can be supplied by 'heroku config:set'.
  - I made a sandbox slack team at https://teabotherers.slack.com/ and put the api key in $SLACK_API_TOKEN. 
- [ ] Add some docs about how to set it up from the command line (I did most of mine using heroku's web configuration UI).
- [x] Work out why my `heroku local` seems to think that psycopg2 isn't installed (`heroku config --shell | sed "s/'//g" > .env && vim Procfile && heroku local` to reproduce).
  - `env LDFLAGS="-I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib" pip --no-cache install psycopg2` to build on mac.
  - also, you can do ```export `heroku config --shell | sed "s/'//g"` && python teabot_endpoints/endpoints.py``` to avoid editing Procfile for debugging.
- [x] Kill off the periodic polling code, and replace it with something that uses pusher (the heroku free-tier plan needs to be idle *most* of the time so that the workers can go to sleep, but the pusher free-tier plan allows 100 concurrent connections (we only need 2) and 200k messages/day, so it makes sense to do it this way instead).