### PR TITLE
feat: DAF-90 - seasonal leaderboard

### DIFF
--- a/teabot_endpoints/models.py
+++ b/teabot_endpoints/models.py
@@ -109,7 +109,7 @@ class State(BaseModel):
     num_of_cups = IntegerField()
     weight = IntegerField(null=True)
     temperature = IntegerField(null=True)
-    claimed_by = ForeignKeyField(PotMaker, null=True)
+    claimed_by = ForeignKeyField(PotMaker, null=True, index=True)
 
     @classmethod
     def get_newest_state(cls):


### PR DESCRIPTION
- Added an endpoint that will accept a date range and return the list of potMakers with their name and largest single pot/number of cups made/number of pots made/total weight of tea made over that time.
- Backward-compatible with the existing potMakers endpoint so we can start using it with the existing front end (though harder on the DB as it's aggregating State).
- (I suspect we'll end up moving historical State somewhere else now that we're more reliant on it for the statistics, but I've kept it as it is for now.)